### PR TITLE
Clear users and ssh keys before publishing image

### DIFF
--- a/files/bsd/rc.local.sh
+++ b/files/bsd/rc.local.sh
@@ -11,7 +11,7 @@ then
     {
         /etc/rc.d/syslogd restart > /dev/null
     }
-    
+
     # chown home paths
     chown_home()
     {
@@ -62,8 +62,8 @@ fi
 
 # There are two types of ssh keys on the GCE; project level and instance level ssh keys.
 # Fetch both of the keys and put them to the related paths
-project_level_ssh_keys=$(curl -s -H "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/project/attributes/ssh-keys)
-instance_level_ssh_keys=$(curl -s -H "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh-keys)
+project_level_ssh_keys=$(curl -fsH "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/project/attributes/ssh-keys)
+instance_level_ssh_keys=$(curl -fsH "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh-keys)
 ssh_keys=$(printf '%s\n%s' "$project_level_ssh_keys" "$instance_level_ssh_keys")
 
 if [ "$ssh_keys" != "" ]
@@ -88,7 +88,10 @@ then
             fi
         elif [ "$username" != "" ]
         then
-            useradd ${username}
+            if ! id "$username" > /dev/null 2>&1;
+            then
+                useradd ${username}
+            fi
             mkdir -p /home/${username}/.ssh
             touch /home/${username}/.ssh/authorized_keys
             chown_home

--- a/packer/bsd/netbsd_postgres.pkr.hcl
+++ b/packer/bsd/netbsd_postgres.pkr.hcl
@@ -33,8 +33,8 @@ build {
     script = "scripts/bsd/netbsd-prep-postgres.sh"
   }
 
-  # clear ssh keys
+  # clear users and ssh keys
   provisioner "shell" {
-    inline = ["rm -rf /home/* && rm -rf /root/.ssh/"]
+    script = "scripts/bsd/clear_users_and_ssh_keys.sh"
   }
 }

--- a/packer/bsd/netbsd_vanilla.pkr.hcl
+++ b/packer/bsd/netbsd_vanilla.pkr.hcl
@@ -106,11 +106,6 @@ build {
     inline = ["chmod 744 /etc/rc.local && chmod 744 /etc/rc.shutdown"]
   }
 
-  # clear ssh keys
-  provisioner "shell" {
-    inline = ["rm -rf /home/* && rm -rf /root/.ssh/"]
-  }
-
   post-processors {
     post-processor "compress" {
       output = "output/netbsd92.tar.gz"

--- a/packer/bsd/openbsd_postgres.pkr.hcl
+++ b/packer/bsd/openbsd_postgres.pkr.hcl
@@ -35,8 +35,8 @@ build {
     script = "scripts/bsd/openbsd-prep-postgres.sh"
   }
 
-  # clear ssh keys
+  # clear users and ssh keys
   provisioner "shell" {
-    inline = ["rm -rf /home/* && rm -rf /root/.ssh/"]
+    script = "scripts/bsd/clear_users_and_ssh_keys.sh"
   }
 }

--- a/packer/bsd/openbsd_vanilla.pkr.hcl
+++ b/packer/bsd/openbsd_vanilla.pkr.hcl
@@ -66,11 +66,6 @@ build {
     inline = ["chmod 744 /etc/rc.local && chmod 744 /etc/rc.shutdown"]
   }
 
-  # clear ssh keys
-  provisioner "shell" {
-    inline = ["rm -rf /home/* && rm -rf /root/.ssh/"]
-  } 
-
   post-processors {
     post-processor "compress" {
       output = "output/openbsd71.tar.gz"

--- a/scripts/bsd/clear_users_and_ssh_keys.sh
+++ b/scripts/bsd/clear_users_and_ssh_keys.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# since we are creating postgres images from vanilla images,
+# vanilla images' rc.local script will create users and
+# these users will exist in postgres images.
+# we need to remove these users.
+
+project_level_ssh_keys=$(curl -fsH "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/project/attributes/ssh-keys)
+instance_level_ssh_keys=$(curl -fsH "Metadata-Flavor: Google"  http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh-keys)
+ssh_keys=$(printf '%s\n%s' "$project_level_ssh_keys" "$instance_level_ssh_keys")
+
+if [ "$ssh_keys" != "" ]
+then
+    echo "$ssh_keys" | while read line
+    do
+        username="$(echo $line | cut -d: -f1)"
+        if [ "$username" != "root" ]
+        then
+            # remove the user's home directory, any subdirectories,
+            # and any files and other entries in them.
+            userdel -r $username
+        fi
+    done
+fi
+
+# remove root's ssh keys
+rm -rf /root/.ssh/


### PR DESCRIPTION
I realized that since we are creating postgres images from vanilla images, vanilla images' rc.local script will create users and these users will exist in postgres images. We need to remove these users. This PR aims to fix that problem.