### PR TITLE
fix: correct openbsd-netbsd image families

### DIFF
--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -126,7 +126,7 @@ build {
     post-processor "googlecompute-import" {
       gcs_object_name   = "packer-${var.image_name}-${var.image_date}.tar.gz"
       bucket            = "${var.bucket}"
-      image_family      = "${local.name}-${var.image_name}"
+      image_family      = "${local.name}-${var.image_name}-${var.version}"
       image_name        = "${local.name}-${var.image_name}-${var.image_date}"
       project_id        = "${var.gcp_project}"
     }
@@ -138,9 +138,9 @@ source "googlecompute" "postgres" {
   disk_type               = "pd-ssd"
   preemptible             = "true"
   project_id              = "${var.gcp_project}"
-  source_image_family     = "${local.name}-${var.name}-${var.version}-vanilla"
+  source_image_family     = "${local.name}-${var.name}-vanilla-${var.version}"
   source_image_project_id = ["${var.gcp_project}"]
-  image_family            = "${local.name}-${var.image_name}"
+  image_family            = "${local.name}-${var.image_name}-${var.version}"
   image_name              = "${local.name}-${var.image_name}-${var.image_date}"
   instance_name           = "build-${var.image_name}-${var.image_date}"
   zone                    = "us-west1-a"


### PR DESCRIPTION
I was working on some openbsd improvements and realized that we were using incorrect images(old images) while using compute_engine_instances.

We were publishing openbsd-netbsd images without 'version' tag, but we were [calling them with 'version' tag](https://github.com/anarazel/postgres/blob/meson/.cirrus.yml#L166). So, actually we were not using recently published images but the old ones.