### PR TITLE
openbsd: Add noatime and softdep to the mount points

### DIFF
--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -28,6 +28,18 @@ pkg_add -I \
     openldap-client--gssapi \
     openldap-server--gssapi
 
+#####
+# Add 'noatime' and 'softdep' to the mount points
+# https://man.openbsd.org/mount.8
+FSTAB_FILE=/etc/fstab
+OPTIONS='noatime,softdep'
+
+cat ${FSTAB_FILE}
+echo "Enabling mount option(s) \"${OPTIONS}\""
+sed -i -e "/ffs/  s/rw/rw,${OPTIONS}/" ${FSTAB_FILE}
+cat ${FSTAB_FILE}
+#####
+
 # Set kernel parameters for running postgres tests
 echo "/sbin/sysctl kern.seminfo.semmni=2048" >> /etc/rc.local
 echo "/sbin/sysctl kern.seminfo.semmns=32768" >> /etc/rc.local


### PR DESCRIPTION
Adding 'noatime' and 'softdep' to the mount points for performance improvements. OpenBSD tasks takes around ~15 minutes now, it was ~22 minutes before. 

Example task: https://cirrus-ci.com/task/5556623333654528

Mount options: https://man.openbsd.org/mount.8

**noatime:**
- Do not update atime on files in the system unless the mtime or ctime is being changed as well. This option is useful for laptops and news servers where one does not want the extra disk activity associated with updating the atime.

**softdep:**
- (FFS only) Mount the file system using soft dependencies. Instead of metadata being written immediately, it is written in an ordered fashion to keep the on-disk state of the file system consistent. This results in significant speedups for file create/delete operations. This option is ignored when using the -u flag and a file system is already mounted read/write.