### PR TITLE
ci: Fix packer does not stop on powershell errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -280,13 +280,13 @@ docker_builder:
 
   env:
     PACKERFILE: packer/windows.pkr.hcl
-    PKRVARFILE: packer/windows.pkrvars.hcl
+    PKRVARFILE: packer/windows_container.pkrvars.hcl
     BUILD_TYPE: docker
 
   platform: windows
   os_version: 2019
 
-  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', '$PACKERFILE', 'scripts/windows*')
+  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', $PACKERFILE, 'scripts/windows*')
 
   <<: *gcp_docker_auth_win
 

--- a/packer/windows_container.pkrvars.hcl
+++ b/packer/windows_container.pkrvars.hcl
@@ -1,0 +1,1 @@
+execute_command = "Invoke-Expression -ErrorAction Stop -Command '. {{.Vars}};. {{.Path}}; exit $LastExitCode'"

--- a/scripts/windows_install_mingw64.ps1
+++ b/scripts/windows_install_mingw64.ps1
@@ -11,7 +11,7 @@ if (!$?) { throw 'cmdfail' };
 Remove-Item msys2.exe ;
 
 echo "setting up msys2 for the first time"
-function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args; if (!$?) { throw 'cmdfail' };} ;
+function msys() { C:\msys64\usr\bin\bash.exe @('-elc') + @Args; if (!$?) { throw 'cmdfail' };} ;
 # When msys is used for the first time, it performs setup tasks. Doing other work in the same invocation does not reliably work.
 msys ' ' ;
 msys 'pacman --noconfirm -Syuu' ;


### PR DESCRIPTION
Adding `$ErrorActionPreference = 'Stop'` is solving VM issue but when it is added to container, it doesn't run scripts. So, I used `Invoke-Expression` for containers. I tried using wrong commands, exit with other than 0, throwing errors and all of them stopped the execution.

For the containers:

We need to use `$ErrorActionPreference = 'Stop'` in inline scripts too because packer is putting these inline commands to the *.ps1; then it executes these files.

But here could be some problems(?):

* Only `Invoke-Expression` worked correctly but there are some issues about that: 

> [Take reasonable precautions when using the Invoke-Expression cmdlet in scripts. When using Invoke-Expression to run a command that the user enters, verify that the command is safe to run before running it. In general, it is best to design your script with predefined input options, rather than allowing freeform input.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-expression?view=powershell-7.3)

* When passing `Invoke-Expression -ErrorAction Stop -Command '. {{.Vars}};. {{.Path}}; exit $LastExitCode'` from .cirrus.yml file, Cirrus always calculates `$LastExitCode` as an environment variable and calls script with `Invoke-Expression -ErrorAction Stop -Command '. {{.Vars}};. {{.Path}}; exit '`. I couldn't escape `$LastExitCode`, so I put this command to var-file instead of .cirrus.yml.