### PR TITLE
Fix IPC:Run installation on MinGW

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,6 +87,7 @@ task:
 
     - env:
         PACKERFILE: packer/linux_debian.pkr.hcl
+        SCRIPTS: scripts/linux_debian_*
 
       matrix:
         - name: bullseye
@@ -96,6 +97,7 @@ task:
 
     - env:
         PACKERFILE: packer/windows.pkr.hcl
+        SCRIPTS: scripts/windows*
 
       matrix:
         - name: windows-ci-vs-2019
@@ -106,7 +108,7 @@ task:
     cpu: 0.5
     memory: 256Mi
 
-  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', 'scripts/linux_debian_*', $PACKERFILE)
+  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', $SCRIPTS, $PACKERFILE)
   auto_cancellation: false
 
   <<: *gcp_auth_unix

--- a/scripts/windows_install_mingw64.ps1
+++ b/scripts/windows_install_mingw64.ps1
@@ -19,9 +19,12 @@ msys 'pacman --noconfirm -Scc' ;
 
 echo 'installing packages' ;
 msys 'pacman -S --needed --noconfirm git bison flex make diffutils \
-    ucrt64/mingw-w64-ucrt-x86_64-{ccache,gcc,icu,libxml2,libxslt,lz4,meson,perl,pkg-config,zlib}' ;
+    ucrt64/mingw-w64-ucrt-x86_64-{ccache,gcc,icu,libxml2,libxslt,lz4,make,meson,perl,pkg-config,zlib}' ;
 msys 'pacman -Scc --noconfirm'
 
 # Install perl modules to enable tap tests
 msys 'where perl'
 msys '(echo; echo o conf recommends_policy 0; echo notest install IPC::Run) | cpan'
+
+# Check if IPC::Run is installed correctly
+msys 'perl -mIPC::Run -e 1'


### PR DESCRIPTION
MinGW was installing both `make-4.4-1` and `mingw-w64-ucrt-x86_64-make-4.4-2` packages before, but it started not to install `mingw-w64-ucrt-x86_64-make-4.4-2` (I am not sure why). I added that package. 

Also, Windows VM installation's `skip: !changesInclude` part didn't have `scripts/windows*` but when this is added; linux images' installation will be triggered too. I refactored that part.

CI Run after fix applied: https://cirrus-ci.com/task/6566742164504576