### PR TITLE
ci: Add family to the images after packer succeeds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,15 +79,6 @@ gcp_docker_auth_win: &gcp_docker_auth_win
     - gcloud auth configure-docker --quiet %GCP_REGION%-docker.pkg.dev
 
 
-# Occasionally image creation succeeds despite signalling a failure.
-# Without further action that'd result in accesses to the image failing
-# due to lacking privileges. Deprecating the image avoids it being used
-# by default, but leaves the image around for potential investigation.
-on_failure_googlecompute: &on_failure_googlecompute
-  deprecate_images_script: |
-    gcloud compute images deprecate --project "$GCP_PROJECT" pg-ci-${CIRRUS_TASK_NAME}-${DATE} --state=DEPRECATED
-
-
 task:
   matrix:
     - name: freebsd-13
@@ -138,14 +129,18 @@ task:
       -var "task_name=${CIRRUS_TASK_NAME}" \
       -var gcp_project=$GCP_PROJECT \
       "$PACKERFILE"
+
+  make_image_public_script: |
     gcloud compute images add-iam-policy-binding \
       --project "$GCP_PROJECT" \
       --member=allAuthenticatedUsers \
       --role=roles/compute.imageUser \
       pg-ci-${CIRRUS_TASK_NAME}-${DATE}
 
-  on_failure:
-    <<: *on_failure_googlecompute
+    gcloud compute images update \
+      --project "$GCP_PROJECT" \
+      --family pg-ci-${CIRRUS_TASK_NAME} \
+      pg-ci-${CIRRUS_TASK_NAME}-${DATE}
 
 
 task:
@@ -153,6 +148,7 @@ task:
     - env:
         PACKERFILE: packer/netbsd_openbsd.pkr.hcl
         PKRVARFILE: packer/openbsd.pkrvars.hcl
+        VERSION: 7-2
       matrix:
         - name: openbsd-vanilla
         - name: openbsd-postgres
@@ -162,6 +158,7 @@ task:
     - env:
         PACKERFILE: packer/netbsd_openbsd.pkr.hcl
         PKRVARFILE: packer/netbsd.pkrvars.hcl
+        VERSION: 9-3
       matrix:
         - name: netbsd-vanilla
         - name: netbsd-postgres
@@ -193,19 +190,24 @@ task:
       -timestamp-ui \
       -force \
       -var-file="${PKRVARFILE}" \
+      -var "version=${VERSION}" \
       -var "image_date=$DATE" \
       -var "image_name=${CIRRUS_TASK_NAME}" \
       -var "bucket=$BUCKET" \
       -var gcp_project=$GCP_PROJECT \
       "$PACKERFILE"
+
+  make_image_public_script: |
     gcloud compute images add-iam-policy-binding \
       --project "$GCP_PROJECT" \
       --member=allAuthenticatedUsers \
       --role=roles/compute.imageUser \
       pg-ci-${CIRRUS_TASK_NAME}-${DATE}
 
-  on_failure:
-    <<: *on_failure_googlecompute
+    gcloud compute images update \
+      --project "$GCP_PROJECT" \
+      --family pg-ci-${CIRRUS_TASK_NAME}-${VERSION} \
+      pg-ci-${CIRRUS_TASK_NAME}-${DATE}
 
 
 # Clean up old images regularly - after a while the individually small cost

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -46,7 +46,6 @@ build {
       # it in the name above, but it seems nicer to have shorter task names anyway
       name = tag.value.name
       image_name = "${local.name}-${tag.value.name}-${var.image_date}"
-      image_family = "${local.name}-${tag.value.name}"
 
       zone = tag.value.zone
       machine_type = tag.value.machine

--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -63,7 +63,6 @@ build {
       # can't reference local. / var. here?!?
       name = tag.value.name
       image_name = "${local.name}-${tag.value.name}-${var.image_date}"
-      image_family = "${local.name}-${tag.value.name}"
 
       zone = tag.value.zone
       machine_type = tag.value.machine

--- a/packer/netbsd.pkrvars.hcl
+++ b/packer/netbsd.pkrvars.hcl
@@ -58,6 +58,5 @@ iso_urls = [
   "https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/images/NetBSD-9.3-amd64.iso"
 ]
 output_file_name = "output/netbsd93.tar.gz"
-version = "9-3"
 vanilla_name = [ { name = "netbsd-vanilla" } ]
 postgres_name = [ { name = "netbsd-postgres" } ]

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -135,7 +135,6 @@ build {
     post-processor "googlecompute-import" {
       gcs_object_name   = "packer-${var.image_name}-${var.image_date}.tar.gz"
       bucket            = "${var.bucket}"
-      image_family      = "${local.name}-${var.image_name}-${var.version}"
       image_name        = local.image_identity
       project_id        = "${var.gcp_project}"
     }
@@ -149,7 +148,6 @@ source "googlecompute" "postgres" {
   project_id              = "${var.gcp_project}"
   source_image_family     = "${local.name}-${var.name}-vanilla-${var.version}"
   source_image_project_id = ["${var.gcp_project}"]
-  image_family            = "${local.name}-${var.image_name}-${var.version}"
   image_name              = local.image_identity
   instance_name           = "build-${var.image_name}-${var.image_date}"
   zone                    = "us-west1-a"

--- a/packer/openbsd.pkrvars.hcl
+++ b/packer/openbsd.pkrvars.hcl
@@ -18,6 +18,5 @@ iso_urls                = [
   "https://cdn.openbsd.org/pub/OpenBSD/7.2/amd64/install72.iso"
 ]
 output_file_name = "output/openbsd72.tar.gz"
-version = "7-2"
 vanilla_name = [ { name = "openbsd-vanilla" } ]
 postgres_name = [ { name = "openbsd-postgres" } ]

--- a/packer/windows.pkr.hcl
+++ b/packer/windows.pkr.hcl
@@ -67,7 +67,6 @@ source "googlecompute" "windows" {
   project_id              = var.gcp_project
   source_image_family     = "windows-2022"
   image_name              = local.image_identity
-  image_family            = "${local.name}-${var.task_name}"
   zone                    = "us-west1-a"
   machine_type            = "n2-standard-4"
   instance_name           = "build-${var.task_name}-${var.image_date}"


### PR DESCRIPTION
Not assign the family inside packer, but do it afterwards, after the permission has been set up.

Fixes #50.