### PR TITLE
ci: Delete VMs older than 23 hours

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,6 +80,20 @@ gcp_docker_auth_win: &gcp_docker_auth_win
 
 
 task:
+  name: cleanup-leftover-running
+
+  container:
+    dockerfile: docker/linux_debian_packer
+    cpu: 0.5
+    memory: 256Mi
+
+  <<: *gcp_auth_unix
+
+  cleanup_leftover_running_script:
+    ./gcp_delete_leftover_running.py
+
+
+task:
   matrix:
     - name: freebsd-13
       env:
@@ -102,6 +116,8 @@ task:
       matrix:
         - name: windows-ci-vs-2019
         - name: windows-ci-mingw64
+
+  depends_on: cleanup-leftover-running
 
   container:
     dockerfile: docker/linux_debian_packer
@@ -151,6 +167,8 @@ task:
         VERSION: 7-2
       matrix:
         - name: openbsd-vanilla
+          depends_on:
+            - cleanup-leftover-running
         - name: openbsd-postgres
           depends_on:
             - openbsd-vanilla
@@ -161,6 +179,8 @@ task:
         VERSION: 9-3
       matrix:
         - name: netbsd-vanilla
+          depends_on:
+            - cleanup-leftover-running
         - name: netbsd-postgres
           depends_on:
             - netbsd-vanilla
@@ -314,6 +334,8 @@ docker_builder:
 
   platform: windows
   os_version: 2019
+
+  depends_on: cleanup-leftover-running
 
   skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', $PACKERFILE, 'scripts/windows*')
 

--- a/gcp_delete_leftover_running.py
+++ b/gcp_delete_leftover_running.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Delete leftover runnings older than 23 hour
+
+import os
+import subprocess
+import sys
+
+
+def delete_leftover_running(type: str):
+    base_cmd = ['gcloud', 'compute', '--project',
+                os.environ['GCP_PROJECT'], type]
+
+    # get objects older than 23 hours with their names and zones
+    # 23 hour is used instead of 1 day because cron job runs daily,
+    # so there could be race conditions
+    get_cmd = base_cmd + ['list', '--format', 'object value(name, zone)',
+                          '--filter', 'creationTimestamp < -P23H']
+    res = subprocess.run(get_cmd, capture_output=True,
+                         check=True, text=True)
+
+    delete_list = []
+    for line in res.stdout.strip().split('\n'):
+        # check if line is not empty
+        if line:
+            linesplit = line.split()
+            delete_list.append({'name': linesplit[0],
+                               'zone': linesplit[1]})
+
+    if delete_list:
+        print(f"{type} to be deleted: ", ', '.join(
+            disk['name'] for disk in delete_list))
+    else:
+        print(f"no {type} to delete")
+
+    for elem in delete_list:
+        print(f'Deleting {type} = {elem["name"]}')
+        delete_cmd = base_cmd + ['delete', elem['name'],
+                                 '--zone', elem['zone'], '--quiet']
+        subprocess.run(delete_cmd, check=True)
+
+
+def main():
+    if 'GCP_PROJECT' not in os.environ:
+        print("GCP_PROJECT not set", file=sys.stderr)
+        sys.exit(1)
+
+    delete_leftover_running('instances')
+    delete_leftover_running('disks')
+
+
+if __name__ == "__main__":
+    main()

--- a/gcp_delete_old_images.py
+++ b/gcp_delete_old_images.py
@@ -7,43 +7,63 @@ import os
 import subprocess
 import sys
 
-if 'GCP_PROJECT' not in os.environ:
-    print("GCP_PROJECT not set", file=sys.stderr)
-    sys.exit(1)
 
-base_cmd = ['gcloud', 'compute', '--project', os.environ['GCP_PROJECT'], 'images']
+def delete_old_images():
+    base_cmd = ['gcloud', 'compute', '--project',
+                os.environ['GCP_PROJECT'], 'images']
 
-# determine all families, no smarter way than listing all images seems to exist
-families_cmd = base_cmd + ['list', '--format', 'object value(family)', '--no-standard-images']
-res = subprocess.run(families_cmd, capture_output = True, check=True, text=True)
-families = set(res.stdout.split())
+    # determine all families, no smarter way than
+    # listing all images seems to exist
+    families_cmd = base_cmd + ['list', '--format',
+                               'object value(family)', '--no-standard-images']
+    res = subprocess.run(families_cmd, capture_output=True,
+                         check=True, text=True)
+    families = set(res.stdout.split())
 
-# find the newest image for each family
-newest_family_members = set()
-for family in families:
-    newest_cmd = base_cmd + ['describe-from-family', '--format', 'object value(name)', family]
-    res = subprocess.run(newest_cmd, capture_output = True, check=True, text=True)
-    newest_family_members.add(res.stdout.strip())
+    # find the newest image for each family
+    newest_family_members = set()
+    for family in families:
+        newest_cmd = base_cmd + ['describe-from-family', '--format',
+                                 'object value(name)', family]
+        res = subprocess.run(newest_cmd, capture_output=True,
+                             check=True, text=True)
+        newest_family_members.add(res.stdout.strip())
 
-# get all old images, including the newest image in a family (will be skipped below)
-old_images_cmd = base_cmd + ['list', '--format', 'object value(name)', '--no-standard-images', '--filter', 'creationTimestamp < -P2W']
-res = subprocess.run(old_images_cmd, capture_output = True, check=True, text=True)
-old_images = res.stdout.split()
+    # get all old images, including the newest image in a
+    # family (will be skipped below)
+    old_images_cmd = base_cmd + ['list', '--format', 'object value(name)',
+                                 '--no-standard-images', '--filter',
+                                 'creationTimestamp < -P2W']
+    res = subprocess.run(old_images_cmd, capture_output=True,
+                         check=True, text=True)
+    old_images = res.stdout.split()
 
-# filter to-be-deleted images by the newest image in a family
-delete_images = []
-for old_image in old_images:
-    if old_image in newest_family_members:
-        print(f"not deleting {old_image}, it's the newest family member")
-    else:
-        delete_images.append(old_image)
+    # filter to-be-deleted images by the newest image in a family
+    delete_images = []
+    for old_image in old_images:
+        if old_image in newest_family_members:
+            print(f"not deleting {old_image}, it's the newest family member")
+        else:
+            delete_images.append(old_image)
 
-if len(delete_images) == 0:
-    print("no images to delete")
-    sys.exit(0)
+    if len(delete_images) == 0:
+        print("no images to delete")
+        sys.exit(0)
 
-print("deleting images: ", ', '.join(delete_images))
+    print("deleting images: ", ', '.join(delete_images))
 
-# finally delete old images
-delete_cmd = base_cmd + ['delete', '--quiet'] + delete_images
-subprocess.run(delete_cmd, check=True)
+    # finally delete old images
+    delete_cmd = base_cmd + ['delete', '--quiet'] + delete_images
+    subprocess.run(delete_cmd, check=True)
+
+
+def main():
+    if 'GCP_PROJECT' not in os.environ:
+        print("GCP_PROJECT not set", file=sys.stderr)
+        sys.exit(1)
+
+    delete_old_images()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There could be some leftover VMs. Clear these VMs because of their costs and to get back the space their disks occupy.

It is set to get VMs older than 23 hours instead of 1 day because cron job runs daily, so there could be race conditions.