### PR TITLE
windows: update openssl to v1.1.1u

### DIFF
--- a/scripts/windows_install_openssl.ps1
+++ b/scripts/windows_install_openssl.ps1
@@ -13,7 +13,7 @@ $ErrorActionPreference = "Stop"
 $filepath = "$Env:TEMP/openssl-setup.exe"
 
 echo "downloading openssl"
-curl.exe -o "$filepath" -fsSL https://slproweb.com/download/Win64OpenSSL-1_1_1t.exe
+curl.exe -o "$filepath" -fsSL https://slproweb.com/download/Win64OpenSSL-1_1_1u.exe
 if (!$?) { throw 'cmdfail' }
 
 echo "installing openssl"


### PR DESCRIPTION
It seems the link is updated, v1.1.1t's link is broken.