### PR TITLE
docker: Fix google-cloud-sdk installation

### DIFF
--- a/docker/linux_debian_packer
+++ b/docker/linux_debian_packer
@@ -13,11 +13,11 @@ RUN \
     colorized-logs \
     expect \
     && \
-  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" > \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] http://packages.cloud.google.com/apt cloud-sdk main" > \
     /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl \
     -fs \
-    -o /usr/share/keyrings/cloud.google.gpg \
+    -o /usr/share/keyrings/cloud.google.asc \
     https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
   apt-get update -y && \
   apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Container installation was failing with google-cloud-sdk's repository is not signed error. ~Tried to use recommended installation method from 'https://cloud.google.com/sdk/docs/install' but it says '--keyring' is deprecated. So, 'gpg' is used for signing google-cloud-sdk's repository.~ 

apt-key manpage states that '.asc' extension needs to be used when ASCII armored keys are used. So, extension of the keyring file is changed to '.asc'