### PR TITLE
ci: Use c2-standard-4 instances

### DIFF
--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -15,7 +15,6 @@ locals {
     {
       name = "${var.task_name}"
       zone = "us-west1-a"
-      machine = "e2-highcpu-4"
     },
   ]
 }
@@ -27,6 +26,7 @@ source "googlecompute" "freebsd-vanilla" {
   project_id              = var.gcp_project
   source_image_family     = "freebsd-13-1"
   source_image_project_id = ["freebsd-org-cloud-dev"]
+  machine_type            = "c2-standard-4"
   ssh_pty                 = "true"
   ssh_username            = "packer"
 }
@@ -48,7 +48,6 @@ build {
       image_name = "${local.name}-${tag.value.name}-${var.image_date}"
 
       zone = tag.value.zone
-      machine_type = tag.value.machine
       instance_name = "build-${tag.value.name}-${var.image_date}"
     }
   }

--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -15,12 +15,12 @@ locals {
     {
       name = "bullseye"
       zone = "us-west1-a"
-      machine = "e2-highcpu-4"
+      machine = "c2-standard-4"
     },
     {
       name = "sid"
       zone = "us-west1-a"
-      machine = "e2-highcpu-4"
+      machine = "c2-standard-4"
     },
     {
       name = "sid-newkernel"

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -151,7 +151,7 @@ source "googlecompute" "postgres" {
   image_name              = local.image_identity
   instance_name           = "build-${var.image_name}-${var.image_date}"
   zone                    = "us-west1-a"
-  machine_type            = "e2-highcpu-4"
+  machine_type            = "c2-standard-4"
   ssh_username            = "root"
   temporary_key_pair_type = "ed25519"
   ssh_timeout             = "300s"


### PR DESCRIPTION
Use c2-standard-4 for the all instances since it is cheaper compared to other instance types.