### PR TITLE
ci: Delete old docker images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -246,19 +246,8 @@ task:
 
   <<: *gcp_auth_unix
 
-  cleanup_vm_images_script:
+  cleanup_images_script:
     ./gcp_delete_old_images.py
-
-  # FIXME: deletion doesn't work 100% reliable, because this doesn't correctly
-  # deal with multi-arch containers (gcloud shows the individual architecture
-  # specific containers without tags, even if the manifest has tags)
-  cleanup_container_images_script: |
-    gcloud artifacts docker images list \
-      --include-tags \
-      --format 'value[separator=@](package,version)' \
-      --filter='createTime < -P14d AND -tags:*' \
-      $GCP_REPO | \
-        xargs --verbose --no-run-if-empty -n 1 gcloud artifacts docker images delete || true
 
 
 task:

--- a/docker/linux_debian_packer
+++ b/docker/linux_debian_packer
@@ -7,6 +7,7 @@ RUN \
     ca-certificates \
     curl \
     packer \
+    podman \
     python3 \
     qemu-system \
     qemu-utils \

--- a/gcp_delete_old_images.py
+++ b/gcp_delete_old_images.py
@@ -3,12 +3,15 @@
 # Delete images older than 2 weeks, except if an image is the newest image in
 # an image family
 
+import json
 import os
 import subprocess
 import sys
 
 
-def delete_old_images():
+def delete_old_vm_images():
+    print("Deleting VM images")
+
     base_cmd = ['gcloud', 'compute', '--project',
                 os.environ['GCP_PROJECT'], 'images']
 
@@ -47,8 +50,8 @@ def delete_old_images():
             delete_images.append(old_image)
 
     if len(delete_images) == 0:
-        print("no images to delete")
-        sys.exit(0)
+        print("no VM images to delete")
+        return
 
     print("deleting images: ", ', '.join(delete_images))
 
@@ -57,12 +60,102 @@ def delete_old_images():
     subprocess.run(delete_cmd, check=True)
 
 
+def delete_old_docker_images_helper(delete_images, base_cmd,
+                                    latest_images_manifests,
+                                    with_tags=False):
+    if not delete_images:
+        print('no docker images to delete ' +
+              ('with tags' if with_tags else 'without tags'))
+        return
+
+    delete_images = [f"{image['package']}@{image['version']}" for
+                     image in delete_images]
+
+    print('deleting docker images ' +
+          ('with tags' if with_tags else 'without tags') +
+          ':\n' + '\n'.join(delete_images))
+
+    for image in delete_images:
+        # Add '--delete-tags' when deleting images with tags, otherwise don't
+        delete_cmd = base_cmd + ['delete', '--quiet'] + \
+            (['--delete-tags', image] if with_tags else [image])
+        subprocess.run(delete_cmd, check=True)
+
+
+def get_manifests(images):
+    latest_images_manifests = set()
+    for image in images:
+        podman_cmd = ['podman', 'manifest', 'inspect',
+                      f'{image["package"]}@{image["version"]}']
+        res = subprocess.run(podman_cmd, capture_output=True,
+                             check=True, text=True)
+        manifest = json.loads(res.stdout)
+
+        if manifest.get('manifests', False):
+            image_manifests = manifest['manifests']
+            for image_manifest in image_manifests:
+                latest_images_manifests.add(image_manifest['digest'])
+
+    return latest_images_manifests
+
+
+def delete_old_docker_images():
+    print("\nDeleting docker images")
+    base_cmd = ['gcloud', 'artifacts', 'docker', 'images']
+    get_images_cmd = base_cmd + ['list',
+                                 '--include-tags', '--format',
+                                 'json(package,version,tags)',
+                                 '--filter', 'createTime < -P2W',
+                                 os.environ['GCP_REPO']]
+    res = subprocess.run(get_images_cmd, capture_output=True,
+                         check=True, text=True)
+    old_images = json.loads(res.stdout)
+
+    if len(old_images) == 0:
+        print("no docker images to delete")
+        return
+
+    images_with_tags = []
+    images_without_tags = []
+    latest_images = []
+    for image in old_images:
+        if 'latest' in image['tags']:
+            latest_images.append(image)
+        elif image['tags']:
+            images_with_tags.append(image)
+        else:
+            images_without_tags.append(image)
+
+    # find the latest images' manifests
+    latest_images_manifests = get_manifests(latest_images)
+
+    # filter to-be-deleted images by the latest images' manifests
+    images_without_tags_filtered = []
+    for image in images_without_tags:
+        if image['version'] in latest_images_manifests:
+            print(f"Not deleting {image['package']}@{image['version']} " +
+                  "because it is manifest of one of the latest images'")
+        else:
+            images_without_tags_filtered.append(image)
+
+    # first we need to call delete images function with images_with_tags
+    # because, images_without_tags depends on the images_with_tags and can't
+    # be deleted if dependent image is not deleted yet.
+    # So, first delete images_with_tags; then images_without_tags.
+    delete_old_docker_images_helper(images_with_tags, base_cmd,
+                                    latest_images_manifests,
+                                    with_tags=True)
+    delete_old_docker_images_helper(images_without_tags_filtered, base_cmd,
+                                    latest_images_manifests)
+
+
 def main():
-    if 'GCP_PROJECT' not in os.environ:
-        print("GCP_PROJECT not set", file=sys.stderr)
+    if 'GCP_PROJECT' not in os.environ or 'GCP_REPO' not in os.environ:
+        print("GCP_PROJECT or GCP_REPO are not set", file=sys.stderr)
         sys.exit(1)
 
-    delete_old_images()
+    delete_old_vm_images()
+    delete_old_docker_images()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When it tries to delete old docker images, it fails with `Precondition check failed` error. This could be related to permission issues. I am creating this PR as a draft because I need change `createTime filter` to 2 weeks and test if it is a permission issue.