### PR TITLE
Bump OpenBSD version in Cirrus task too.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -165,7 +165,7 @@ task:
     - env:
         PACKERFILE: packer/netbsd_openbsd.pkr.hcl
         PKRVARFILE: packer/openbsd.pkrvars.hcl
-        VERSION: 7-2
+        VERSION: 7-3
       matrix:
         - name: openbsd-vanilla
           depends_on:


### PR DESCRIPTION
The actual version was bumped in https://github.com/anarazel/pg-vm-images/pull/60, but the version in .cirrus.yml wasn't bumped, meaning the image family still ended with 7-2.