### PR TITLE
ci: Install latest meson version to CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,10 @@ env:
   GCP_PROJECT_MAIN: pg-ci-images
   GCP_PROJECT_DEV: pg-ci-images-dev
 
+  # default variables to use in local meson installations
+  MESON_REPO: https://github.com/mesonbuild/meson.git
+  MESON_BRANCH: master
+
   # the following variables are chosen in .cirrus.star, based on the branch
   # being built etc
   # BRANCH_TYPE = dev|main
@@ -154,6 +158,8 @@ task:
       -force \
       -var "image_date=$DATE" \
       -var "image_name=${IMAGE_NAME}" \
+      -var "meson_repo=${MESON_REPO}" \
+      -var "meson_branch=${MESON_BRANCH}" \
       -var gcp_project=$GCP_PROJECT \
       "$PACKERFILE"
 

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -1,6 +1,8 @@
 variable "image_date" { type = string }
 variable "gcp_project" { type = string }
 variable "image_name" { type = string }
+variable "meson_repo" { type = string }
+variable "meson_branch" { type = string }
 
 locals {
   image_identity = "${var.image_name}-${var.image_date}"
@@ -67,7 +69,6 @@ build {
           bash \
           git-tiny \
           gmake \
-          meson \
           ninja \
           perl5 \
           pkgconf \
@@ -92,6 +93,8 @@ build {
           krb5 \
           openldap25-client \
           openldap25-server
+
+        python3 -m pip install git+${var.meson_repo}@${var.meson_branch}
 
         # remove temporary files
         pkg clean -ay

--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -1,6 +1,8 @@
 variable "image_date" { type = string }
 variable "gcp_project" { type = string }
 variable "image_name" { type = string }
+variable "meson_repo" { type = string }
+variable "meson_branch" { type = string }
 
 locals {
   image_identity = "${var.image_name}-${var.image_date}"
@@ -187,6 +189,21 @@ build {
   provisioner "shell" {
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     script = "scripts/linux_debian_install_deps.sh"
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = ["python3 -m pip install git+${var.meson_repo}@${var.meson_branch} ninja"]
+    only = ["googlecompute.bullseye"]
+  }
+
+  # These gives 'error: externally-managed-environment'
+  # Also, these images install one of the latest version of meson
+  # See PEP 668 for the detailed specification.
+  provisioner "shell" {
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = ["apt-get -y install --no-install-recommends meson"]
+    only = ["googlecompute.sid", "googlecompute.sid-newkernel", "googlecompute.sid-newkernel-uring"]
   }
 
   provisioner "shell" {

--- a/packer/windows.pkr.hcl
+++ b/packer/windows.pkr.hcl
@@ -1,5 +1,7 @@
 variable "image_name" { type = string }
 variable "image_date" { type = string }
+variable "meson_repo" { type = string }
+variable "meson_branch" { type = string }
 
 variable "build_type" {
   type = string
@@ -114,7 +116,7 @@ build {
     execute_command = var.execute_command
     inline = [
       "$ErrorActionPreference = 'Stop'",
-      "py -m pip install meson ninja"
+      "python3 -m pip install git+${var.meson_repo}@${var.meson_branch} ninja",
     ]
   }
 

--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -11,7 +11,6 @@ apt-get -y install --no-install-recommends \
   gdb \
   git \
   make \
-  meson \
   perl \
   pkg-config \
   \


### PR DESCRIPTION
I am not sure if that makes sense since most probably PG users will install meson from official repositories instead of PIP. So, this change could mask some errors but also makes easier to catch future errors. I didn't install this for netBSD, openBSD and MinGW but I can do that if you like the idea.