### PR TITLE
Remove version suffix from {Net,Open}BSD image family name.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,7 +179,6 @@ task:
   matrix:
     - env:
         PKRVARFILE: packer/openbsd.pkrvars.hcl
-        VERSION: 7-3
       matrix:
         - env:
             TASK_NAME: openbsd-vanilla
@@ -192,7 +191,6 @@ task:
 
     - env:
         PKRVARFILE: packer/netbsd.pkrvars.hcl
-        VERSION: 9-3
 
       matrix:
         - env:
@@ -233,7 +231,6 @@ task:
       -timestamp-ui \
       -force \
       -var-file="${PKRVARFILE}" \
-      -var "version=${VERSION}" \
       -var "image_date=$DATE" \
       -var "image_name=${IMAGE_NAME}" \
       -var "prefix=${PREFIX}" \
@@ -250,7 +247,7 @@ task:
 
     gcloud compute images update \
       --project "$GCP_PROJECT" \
-      --family ${IMAGE_NAME}-${VERSION} \
+      --family ${IMAGE_NAME} \
       ${IMAGE_NAME}-${DATE}
 
 
@@ -367,11 +364,11 @@ task:
   name: 'Testing VM Image: ${PREFIX}-${IMAGE_NAME}'
   matrix:
     - env:
-        IMAGE_NAME: netbsd-postgres-9-3
+        IMAGE_NAME: netbsd-postgres
         PLATFORM: netbsd
 
     - env:
-        IMAGE_NAME: openbsd-postgres-7-2
+        IMAGE_NAME: openbsd-postgres
         PLATFORM: openbsd
 
   depends_on:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ pre-commit:
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=netbsd-vanilla" \
 	  -var "prefix=${PREFIX}" \
-	  -var "version=${VERSION}" \
 	  -var "bucket=somebucket" \
 	  packer/netbsd_openbsd.pkr.hcl
 #	NetBSD Postgres
@@ -46,7 +45,6 @@ pre-commit:
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=netbsd-postgres" \
 	  -var "prefix=${PREFIX}" \
-	  -var "version=${VERSION}" \
 	  -var "bucket=somebucket" \
 	  packer/netbsd_openbsd.pkr.hcl
 #	OpenBSD Vanilla
@@ -57,7 +55,6 @@ pre-commit:
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=openbsd-vanilla" \
 	  -var "prefix=${PREFIX}" \
-	  -var "version=${VERSION}" \
 	  -var "bucket=somebucket" \
 	  packer/netbsd_openbsd.pkr.hcl
 #	OpenBSD Postgres
@@ -68,6 +65,5 @@ pre-commit:
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=openbsd-postgres" \
 	  -var "prefix=${PREFIX}" \
-	  -var "version=${VERSION}" \
 	  -var "bucket=somebucket" \
 	  packer/netbsd_openbsd.pkr.hcl

--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ The following images are available:
     [official GCP images](https://cloud.google.com/compute/docs/images#freebsd).)
 
 -   NetBSD and OpenBSD images are available both with and without Postgres,
-    in families `pg-ci-{net,open}bsd-{vanilla,postgres}-$version`. Find
-    the current value of `$version` in
-    [packer/netbsd.pkrvars.hcl](packer/netbsd.pkrvars.hcl) and
-    [packer/openbsd.pkrvars.hcl](packer/openbsd.pkrvars.hcl).
+    in families `pg-ci-{net,open}bsd-{vanilla,postgres}`.
 
 
 ## How it works

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -9,7 +9,6 @@ variable "name" { type = string }
 variable "output_file_name" { type = string }
 variable "postgres_name" { type = list(map(string)) }
 variable "vanilla_name" { type = list(map(string)) }
-variable "version" { type = string }
 variable "prefix" {type = string }
 
 locals {
@@ -141,7 +140,7 @@ source "googlecompute" "postgres" {
   disk_type               = "pd-ssd"
   preemptible             = "true"
   project_id              = "${var.gcp_project}"
-  source_image_family     = "${var.prefix}-${var.name}-vanilla-${var.version}"
+  source_image_family     = "${var.prefix}-${var.name}-vanilla"
   source_image_project_id = ["${var.gcp_project}"]
   image_name              = local.image_identity
   instance_name           = "build-${local.image_identity}"


### PR DESCRIPTION
This originally was https://github.com/anarazel/pg-vm-images/pull/85 but github automatically closed it when I pushed a too old version for a rebase - now I can't push again. 