### PR TITLE
linux: Upgrade Debian from 11 (bullseye) to 12 (bookworm)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,6 +111,8 @@ task:
 
       matrix:
         - env:
+            TASK_NAME: bookworm
+        - env:
             TASK_NAME: bullseye
         - env:
             TASK_NAME: sid
@@ -281,10 +283,17 @@ task:
     platform: linux
     cpu: 2
     memory: 8G
-  env:
-    IMAGE: linux_debian_bullseye_ci
+  matrix:
+    - env:
+        DOCKER_FILE: linux_debian_ci
+        IMAGE: linux_debian_${DEBIAN_RELEASE}_ci
+      matrix:
+        - env:
+            DEBIAN_RELEASE: bullseye
+        - env:
+            DEBIAN_RELEASE: bookworm
 
-  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'scripts/linux_debian*', 'docker/linux_debian_bullseye_ci')
+  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'scripts/linux_debian*', 'docker/linux_debian_ci')
 
   <<: *gcp_docker_auth_unix
 
@@ -311,9 +320,10 @@ task:
       --platform linux/amd64 \
       --build-arg DATE=$DATE \
       --build-arg IMAGE_NAME=$IMAGE \
+      --build-arg DEBIAN_RELEASE=$DEBIAN_RELEASE \
       --tag $GCP_REPO/$IMAGE:latest \
       --tag $GCP_REPO/$IMAGE:$DATE \
-      -f docker/$IMAGE \
+      -f docker/$DOCKER_FILE \
       --push \
       .
 
@@ -322,8 +332,11 @@ task:
 
 task:
   name: 'Testing Container Image: ${IMAGE_NAME}'
-  env:
-    IMAGE_NAME: linux_debian_bullseye_ci
+  matrix:
+    - env:
+        IMAGE_NAME: linux_debian_bullseye_ci
+    - env:
+        IMAGE_NAME: linux_debian_bookworm_ci
   depends_on:
     - dockerbuild-${IMAGE_NAME}
   container:
@@ -334,12 +347,17 @@ task:
     - env
 
 # Disabled linux/arm64, fails currently due to reasons outside of our control
-#task:
-#  name: test-linux-container-arm64
+# task:
+#  name: 'Testing Arm Container Image: ${IMAGE_NAME}'
+#   matrix:
+#     - env:
+#         IMAGE_NAME: linux_debian_bullseye_ci
+#     - env:
+#         IMAGE_NAME: linux_debian_bookworm_ci
 #  depends_on:
-#    - linux_debian_bullseye_ci
+#    - ${IMAGE_NAME}
 #  arm_container:
-#    image: $GCP_REPO/linux_debian_bullseye_ci:latest
+#    image: $GCP_REPO/${IMAGE_NAME}:latest
 #  test_script:
 #    - uname -a
 #    - xsltproc --version

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,17 @@ pre-commit:
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=freebsd-13" \
 	  packer/freebsd.pkr.hcl
-#	Debian
+#	Debian Bullseye
 	packer validate \
 	  -var gcp_project=pg-ci-images-dev \
 	  -var "image_date=$(IMAGE_DATE)" \
 	  -var "image_name=bullseye" \
+	  packer/linux_debian.pkr.hcl
+#	Debian Bookworm
+	packer validate \
+	  -var gcp_project=pg-ci-images-dev \
+	  -var "image_date=$(IMAGE_DATE)" \
+	  -var "image_name=bookworm" \
 	  packer/linux_debian.pkr.hcl
 #	Windows VM
 	packer validate \

--- a/docker/linux_debian_ci
+++ b/docker/linux_debian_ci
@@ -1,4 +1,6 @@
-FROM debian:bullseye
+ARG DEBIAN_RELEASE
+
+FROM debian:${DEBIAN_RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
I tested the new debian 12 images, CI run: https://cirrus-ci.com/build/4851369497067520
```
# install grub again, otherwise grub fails with:
# error: file `/boot/grub/x86_64-efi/bli.mod' not found.
grub-install --target=x86_64-efi --efi-directory=/boot/efi
```

fixes the errors while creating debian 11 images too. I could make it separate commit or create another PR for it.

I didn't update 'linux_debian_packer' to bookworm because 'Clean up old images' started to fail. CI run: https://cirrus-ci.com/task/4831203417653248.
I spent some time but I couldn't fix it yet. The podman command fails with:
- 'overlay is not supported over overlayfs'. I am able to fix it with installing 'fuse-overlayfs'. Then it failed with:
- '/var/lib/containers/storage/overlay flags: 0x1000: permission denied'. I couldn't fix it yet. It is said that it could be related with apparmor on web.