### PR TITLE
Downgrade FreeBSD p5-IO-Tty 1.18->1.17.

### DIFF
--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -93,6 +93,19 @@ build {
           openldap25-client \
           openldap25-server
 
+        # === begin temporary workaround for broken p5-IO-Tty 1.18 ===
+        # https://github.com/cpan-authors/IO-Tty/issues/38
+        # https://www.postgresql.org/message-id/flat/757523.1705091568%40sss.pgh.pa.us
+        if pkg info p5-IO-Tty | grep -E '^Version *: *1.18$' ; then
+          GOOD_PKG="p5-IO-Tty-1.17.pkg"
+          pkg remove -y p5-IO-Tty
+          curl -O "https://pkg.freebsd.org/freebsd:13:x86:64/release_2/All/$GOOD_PKG"
+          pkg install -y $GOOD_PKG
+          rm $GOOD_PKG
+          pkg install -y p5-IPC-Run
+        fi
+        # === end temporary workaround for broken p5-IO-Tty ===
+
         # remove temporary files
         pkg clean -ay
         rm -fr /usr/ports /usr/src /usr/tests /usr/lib/debug


### PR DESCRIPTION
There seems to be a problem in 1.18 that breaks PostgreSQL's interactive tests.  Until a fixed package rolls out, downgrade to 1.17 if 1.18 is detected.

https://github.com/cpan-authors/IO-Tty/issues/38
https://www.postgresql.org/message-id/flat/757523.1705091568%40sss.pgh.pa.us