### PR TITLE
Update work-around for FreeBSD p5-IO-Tty package.

### DIFF
--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -93,10 +93,10 @@ build {
           openldap25-client \
           openldap25-server
 
-        # === begin temporary workaround for broken p5-IO-Tty 1.18 ===
+        # === begin temporary workaround for broken p5-IO-Tty 1.20 ===
         # https://github.com/cpan-authors/IO-Tty/issues/38
         # https://www.postgresql.org/message-id/flat/757523.1705091568%40sss.pgh.pa.us
-        if pkg info p5-IO-Tty | grep -E '^Version *: *1.18$' ; then
+        if pkg info p5-IO-Tty | grep -E '^Version *: *1.20$' ; then
           GOOD_PKG="p5-IO-Tty-1.17.pkg"
           pkg remove -y p5-IO-Tty
           curl -O "https://pkg.freebsd.org/freebsd:13:x86:64/release_2/All/$GOOD_PKG"


### PR DESCRIPTION
FreeBSD got a new version 1.20 which is still not fixed.  Unfortunately my earlier workaround would only do a downgrade 1.18->1.17, thinking that the next release would surely be fixed, so we'd get a smooth transition when the new package showed up.  But it's still broken, so we must now downgrade 1.20->1.17.

Fortunately the real fix is coming, hopefully in the next package, based on:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276535