### PR TITLE
Fix NetBSD build failures

### DIFF
--- a/scripts/bsd/netbsd-prep-gce.sh
+++ b/scripts/bsd/netbsd-prep-gce.sh
@@ -12,6 +12,7 @@ EOF
 PKG_PATH="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/" && \
 export PKG_PATH && \
 pkg_add pkgin && \
+echo $PKG_PATH > /usr/pkg/etc/pkgin/repositories.conf && \
 pkgin update && \
 pkgin upgrade -y && \
 pkgin -y install \


### PR DESCRIPTION
pkgin's repository is not updated when it is installed, it was using NetBSD 9.0's repository, so update pkgin's repository after it is installed.

This should fix recent NetBSD failures.