### PR TITLE
linux: Move ARG and ENV variables to the end of the dockerfile

### DIFF
--- a/docker/linux_debian_bullseye_ci
+++ b/docker/linux_debian_bullseye_ci
@@ -1,7 +1,6 @@
 FROM debian:bullseye
 
-ARG DATE IMAGE_NAME
-ENV DEBIAN_FRONTEND=noninteractive IMAGE_IDENTITY=$IMAGE_NAME-$DATE
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY /scripts/linux_debian_install_deps.sh /scripts/
 
@@ -11,3 +10,7 @@ RUN \
   /scripts/linux_debian_install_deps.sh && \
   rm /scripts/linux_debian_install_deps.sh && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ARG DATE IMAGE_NAME
+
+ENV IMAGE_IDENTITY=$IMAGE_NAME-$DATE


### PR DESCRIPTION
Using variables whose values could be *different than previous build* causes cache miss. So, move these kind of variables to the end of the dockerfile.

See: https://docs.docker.com/reference/dockerfile/#impact-on-build-caching

Please merge this PR before #91 as both have the same commit.