### PR TITLE
Revert "windows: Install ccache on VM image"

### DIFF
--- a/packer/windows.pkr.hcl
+++ b/packer/windows.pkr.hcl
@@ -81,7 +81,6 @@ build {
 
       "choco install -y --no-progress 7zip",
       "choco install -y --no-progress git --parameters=\"/GitAndUnixToolsOnPath\"",
-      "choco install -y --no-progress ccache"
     ]
   }
 


### PR DESCRIPTION
Reverts anarazel/pg-vm-images#99

As it turns out the choco ccache is slower, due to some wrappers choco uses. It's faster to just the mingw one.