### PR TITLE
{Net,Open}BSD upgrade and improvements

### DIFF
--- a/files/bsd/rc.local.sh
+++ b/files/bsd/rc.local.sh
@@ -2,9 +2,9 @@
 
 # Save to /etc/rc.local, to be ran on startup
 
-# Set IMAGE_IDENTITY variable
+# Set [BASE_]IMAGE_IDENTITY variables
 . /etc/environment.d/image_identity.conf
-export IMAGE_IDENTITY
+export BASE_IMAGE_IDENTITY IMAGE_IDENTITY
 
 if [ "$(uname)" = "NetBSD" ]
 then

--- a/packer/netbsd.pkrvars.hcl
+++ b/packer/netbsd.pkrvars.hcl
@@ -28,16 +28,16 @@ boot_command = [
   "<enter><wait300s>",
   # Continue
   "<enter><wait5s>",
-  # Enable sshd
-  "g<enter><wait5s>",
-  # Change root password
-  "d<enter><wait5s><enter><wait5s>",
   # Set root password
   "packer<enter><wait5s>",
   # Set root password again
   "packer<enter><wait5s>",
   # Set root password again
   "packer<enter><wait5s>",
+  # Skip 'cryptographically strong pseudo random' warning
+  "x<enter><wait5s>",
+  # Enable sshd
+  "g<enter><wait5s>",
   # Finished configuring
   "x<enter><wait5s>",
   # Continue
@@ -52,11 +52,11 @@ boot_command = [
   "echo '/sbin/dhcpcd -4' > /etc/rc.local<enter><wait5s>",
   "reboot<enter>"
 ]
-iso_checksum = "sha256:7e7f03bfd0584480cd11ed8833963310e34361d105498a028a2ebf3c10354171"
+iso_checksum = "sha256:59afa864ce54b70cadffe846a251cb8462e868188154cbb1babfa92bebf1c2a0"
 iso_urls = [
-  "NetBSD-9.3-amd64.iso",
-  "https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/images/NetBSD-9.3-amd64.iso"
+  "NetBSD-10.0-amd64.iso",
+  "https://cdn.netbsd.org/pub/NetBSD/NetBSD-10.0/images/NetBSD-10.0-amd64.iso"
 ]
-output_file_name = "output/netbsd93.tar.gz"
+output_file_name = "output/netbsd10-0.tar.gz"
 vanilla_name = [ { name = "netbsd-vanilla" } ]
 postgres_name = [ { name = "netbsd-postgres" } ]

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -84,7 +84,7 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p /etc/environment.d",
-      "echo \"IMAGE_IDENTITY=${local.image_identity}\" | tee /etc/environment.d/image_identity.conf",
+      "echo \"BASE_IMAGE_IDENTITY=${local.image_identity}\" | tee -a /etc/environment.d/image_identity.conf",
     ]
   }
 
@@ -179,7 +179,7 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p /etc/environment.d",
-      "echo \"IMAGE_IDENTITY=${local.image_identity}\" | tee /etc/environment.d/image_identity.conf",
+      "echo \"IMAGE_IDENTITY=${local.image_identity}\" | tee -a /etc/environment.d/image_identity.conf",
     ]
   }
 

--- a/packer/openbsd.pkrvars.hcl
+++ b/packer/openbsd.pkrvars.hcl
@@ -12,11 +12,11 @@ boot_command = [
   "EOF<enter>",
   "install -af install.conf && reboot<enter>"
 ]
-iso_checksum = "sha256:fdf1210ffe87213eeca5f1d317e8b19364cbae83545cdfc7845098a53fc79a60"
+iso_checksum = "sha256:034435c6e27405d5a7fafb058162943c194eb793dafdc412c08d49bb56b3892a"
 iso_urls                = [
-  "install73.iso",
-  "https://cdn.openbsd.org/pub/OpenBSD/7.3/amd64/install73.iso"
+  "install75.iso",
+  "https://cdn.openbsd.org/pub/OpenBSD/7.5/amd64/install75.iso"
 ]
-output_file_name = "output/openbsd73.tar.gz"
+output_file_name = "output/openbsd7-5.tar.gz"
 vanilla_name = [ { name = "openbsd-vanilla" } ]
 postgres_name = [ { name = "openbsd-postgres" } ]

--- a/scripts/bsd/clear_users_and_ssh_keys.sh
+++ b/scripts/bsd/clear_users_and_ssh_keys.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if [ "$(uname)" = "NetBSD" ]
 then
     export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/pkg/bin:/usr/pkg/sbin

--- a/scripts/bsd/netbsd-prep-gce.sh
+++ b/scripts/bsd/netbsd-prep-gce.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/pkg/bin:/usr/pkg/sbin
 
 # Network

--- a/scripts/bsd/netbsd-prep-gce.sh
+++ b/scripts/bsd/netbsd-prep-gce.sh
@@ -18,6 +18,4 @@ echo $PKG_PATH > /usr/pkg/etc/pkgin/repositories.conf && \
 pkgin update && \
 pkgin upgrade -y && \
 pkgin -y install \
-    curl \
-    mozilla-rootcerts && \
-mozilla-rootcerts install
+    curl

--- a/scripts/bsd/netbsd-prep-postgres.sh
+++ b/scripts/bsd/netbsd-prep-postgres.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/pkg/bin:/usr/pkg/sbin
 
 # Install required packages for running tests on netBSD

--- a/scripts/bsd/openbsd-prep-gce.sh
+++ b/scripts/bsd/openbsd-prep-gce.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Patch
 syspatch
 

--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 pkg_add -I \
     vim--no_x11 git \
     bash \

--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PYTHON_VERSION=3.9
+
 pkg_add -I \
     vim--no_x11 git \
     bash \
@@ -21,7 +23,7 @@ pkg_add -I \
     libxslt \
     lz4 \
     openpam \
-    python%3.9 \
+    python%${PYTHON_VERSION} \
     readline \
     tcl%8.6 \
     zstd \
@@ -29,6 +31,9 @@ pkg_add -I \
     login_krb5 \
     openldap-client--gssapi \
     openldap-server--gssapi
+
+# create a symbolic link to python3, then upgrade pip
+ln -sf /usr/local/bin/python${PYTHON_VERSION} /usr/local/bin/python3
 python3 -m ensurepip --upgrade
 
 #####


### PR DESCRIPTION
To see all changes from one place, I did not create separate PRs. I can create seperate PRs if you prefer that. If you plan to merge this PR, please merge #89 before.

* Improvements:
  * bsd: Add BASE_IMAGE_IDENTITY variable
  * bsd: Add 'set -e' to the BSD shell scripts

* Bug fix:
  * openbsd: Fix python3 installation on OpenBSD

* Upgrade:
  * openbsd: Upgrade OpenBSD to 7.5
  * netbsd: Upgrade NetBSD to 10.0
  
* CI Run after all the changes applied: https://cirrus-ci.com/build/6444335992930304

