### PR TITLE
netbsd: Bump Python version to 3.12

### DIFF
--- a/scripts/bsd/netbsd-prep-postgres.sh
+++ b/scripts/bsd/netbsd-prep-postgres.sh
@@ -16,16 +16,16 @@ pkgin -y install \
     p5-IPC-Run \
     flex \
     pkgconf \
-    python39 \
-    py39-pip \
+    python312 \
+    py312-pip \
     icu \
     lz4 \
     libxslt \
     tcl \
     zstd
 
-echo "alias python3=python3.9" >> ~/.bashrc
-echo "alias pip3=pip3.9" >> ~/.bashrc
+echo "alias python3=python3.12" >> ~/.bashrc
+echo "alias pip3=pip3.12" >> ~/.bashrc
 
 # Set kernel parameters for running postgres tests
 echo "sysctl -w kern.ipc.semmni=2048" >> /etc/rc.local


### PR DESCRIPTION
Python 3.9 is not available anymore on NetBSD, so bump it to 3.12.