### PR TITLE
bsd: Install sudo in OpenBSD and NetBSD

### DIFF
--- a/scripts/bsd/netbsd-prep-gce.sh
+++ b/scripts/bsd/netbsd-prep-gce.sh
@@ -19,3 +19,7 @@ pkgin update && \
 pkgin upgrade -y && \
 pkgin -y install \
     curl
+
+# Install sudo and then set its configuration to 'users can access sudo without password'
+pkgin -y install sudo
+echo '%wheel ALL=(ALL:ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo

--- a/scripts/bsd/openbsd-prep-gce.sh
+++ b/scripts/bsd/openbsd-prep-gce.sh
@@ -23,3 +23,7 @@ pkg_add -uvI
 
 # Install curl for startup & shutdown scripts
 pkg_add -I curl
+
+# Install sudo and then set its configuration to 'users can access sudo without password'
+pkg_add -I sudo--
+echo '%wheel ALL=(ALL) NOPASSWD: SETENV: ALL' | sudo EDITOR='tee -a' visudo


### PR DESCRIPTION
If there is no ssh-key whose username is root, then it was impossible to access root permissions. With this change, all users can access root permissions by using sudo command.