### PR TITLE
netbsd: Install mit-krb5 package for gss to work

### DIFF
--- a/files/bsd/rc.local.sh
+++ b/files/bsd/rc.local.sh
@@ -8,7 +8,7 @@ export BASE_IMAGE_IDENTITY IMAGE_IDENTITY
 
 if [ "$(uname)" = "NetBSD" ]
 then
-    export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/pkg/bin:/usr/pkg/sbin
+    export PATH=/usr/pkg/bin:/usr/pkg/sbin:/usr/bin:/bin:/usr/sbin:/sbin
 
     # restarting syslogd
     restart_syslogd()

--- a/scripts/bsd/netbsd-prep-postgres.sh
+++ b/scripts/bsd/netbsd-prep-postgres.sh
@@ -21,6 +21,7 @@ pkgin -y install \
     icu \
     lz4 \
     libxslt \
+    mit-krb5 \
     tcl \
     zstd
 


### PR DESCRIPTION
This patch installs mit-krb5 package for gss to work on NetBSD.