### PR TITLE
freebsd: Upgrade to 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,7 +102,7 @@ task:
   alias: vmbuild-${TASK_NAME}
   matrix:
     - env:
-        TASK_NAME: freebsd-13
+        TASK_NAME: freebsd-14
         PACKERFILE: packer/freebsd.pkr.hcl
 
     - env:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ pre-commit:
 	packer validate \
 	  -var gcp_project=pg-ci-images-dev \
 	  -var "image_date=$(IMAGE_DATE)" \
-	  -var "image_name=freebsd-13" \
+	  -var "image_name=freebsd-14" \
 	  packer/freebsd.pkr.hcl
 #	Debian Bullseye
 	packer validate \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ foo_task:
 
 The following images are available:
 
--   FreeBSD images with Postgres are available in the family `pg-ci-freebsd-13`.
+-   FreeBSD images with Postgres are available in the family `pg-ci-freebsd-14`.
     (If you are looking for images without Postgres, just use FreeBSD's
     [official GCP images](https://cloud.google.com/compute/docs/images#freebsd).)
 

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -7,7 +7,7 @@ locals {
 
   freebsd_gcp_images = [
     {
-      task_name = "freebsd-13"
+      task_name = "freebsd-14"
       zone = "us-west1-a"
     },
   ]
@@ -20,11 +20,12 @@ source "googlecompute" "freebsd-vanilla" {
   project_id              = var.gcp_project
   image_name              = "${local.image_identity}"
   instance_name           = "build-${local.image_identity}"
-  source_image_family     = "freebsd-13-3"
+  source_image_family     = "freebsd-14-2"
   source_image_project_id = ["freebsd-org-cloud-dev"]
   machine_type            = "t2d-standard-2"
   ssh_pty                 = "true"
   ssh_username            = "packer"
+  temporary_key_pair_type = "ed25519"
 }
 
 
@@ -97,7 +98,7 @@ build {
         if pkg info p5-IO-Tty | grep -E '^Version *: *1.20$' ; then
           GOOD_PKG="p5-IO-Tty-1.17.pkg"
           pkg remove -y p5-IO-Tty
-          curl -O "https://pkg.freebsd.org/freebsd:13:x86:64/release_2/All/$GOOD_PKG"
+          curl -O "https://pkg.freebsd.org/freebsd:14:x86:64/release_0/All/$GOOD_PKG"
           pkg install -y $GOOD_PKG
           rm $GOOD_PKG
           pkg install -y p5-IPC-Run
@@ -147,10 +148,6 @@ build {
         echo 'kern.timecounter.invariant_tsc=1' | tee -a /boot/loader.conf
         echo 'kern.timecounter.smp_tsc=1' | tee -a /boot/loader.conf
         echo 'kern.timecounter.smp_tsc_adjust=1' | tee -a /boot/loader.conf
-
-        # Freebsd 13.2 causes problems with tcl if the timezone is not explicitly configured
-        # https://postgr.es/m/20230731191510.pebqeiuo2sbmlcfh%40awork3.anarazel.de
-        tzsetup UTC
       SCRIPT
     ]
   }


### PR DESCRIPTION
freeBSD 13.3 has reached its EOL, update needs to be done. There is already a new major freeBSD version (14). So, instead of updating it to 13.*, upgrade it to 14.2.

This also fixes the TCL problem, so this part of the code is removed.

---

~packer needs to be updated, otherwise freeBSD task hangs at SSH part. Please merge #110 first.~

Postgres CI task that uses freeBSD 14.2: https://cirrus-ci.com/task/6206335622053888

(Also I am sorry that I used your freebsd-14 branch by mistake.)