### PR TITLE
docker: Install latest packer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,6 +145,9 @@ task:
   info_script:
     - packer --version
 
+  packer_init_script:
+    - packer init ${PACKERFILE}
+
   export_date_script: |
     DATE=$(date --utc +'%Y-%m-%dt%H-%M-%S')
     echo "DATE=${DATE}" | tee -a $CIRRUS_ENV
@@ -218,6 +221,9 @@ task:
 
   info_script:
     - packer --version
+
+  packer_init_script:
+    - packer init ${PACKERFILE}
 
   export_date_script: |
     DATE=$(date --utc +'%Y-%m-%dt%H-%M-%S')

--- a/docker/linux_debian_packer
+++ b/docker/linux_debian_packer
@@ -19,9 +19,17 @@ RUN \
   curl \
     -fs \
     -o /usr/share/keyrings/cloud.google.asc \
-    https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
+    https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    && \
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.asc] https://apt.releases.hashicorp.com bullseye main" > \
+    /etc/apt/sources.list.d/hashicorp.list && \
+  curl \
+    -fs \
+    -o /usr/share/keyrings/hashicorp-archive-keyring.asc \
+    https://apt.releases.hashicorp.com/gpg \
+    && \
   apt-get update -y && \
   apt-get install --no-install-recommends -y \
-    google-cloud-sdk \
+    google-cloud-sdk packer \
     && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -2,6 +2,15 @@ variable "image_date" { type = string }
 variable "gcp_project" { type = string }
 variable "image_name" { type = string }
 
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+  }
+}
+
 locals {
   image_identity = "${var.image_name}-${var.image_date}"
 

--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -2,6 +2,15 @@ variable "image_date" { type = string }
 variable "gcp_project" { type = string }
 variable "image_name" { type = string }
 
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+  }
+}
+
 locals {
   image_identity = "${var.image_name}-${var.image_date}"
 

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -11,6 +11,19 @@ variable "postgres_name" { type = list(map(string)) }
 variable "vanilla_name" { type = list(map(string)) }
 variable "prefix" {type = string }
 
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+    qemu = {
+      version = "~> 1"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
 locals {
   image_identity = "${var.image_name}-${var.image_date}"
 }

--- a/packer/windows.pkr.hcl
+++ b/packer/windows.pkr.hcl
@@ -1,6 +1,15 @@
 variable "image_name" { type = string }
 variable "image_date" { type = string }
 
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+  }
+}
+
 variable "build_type" {
   type = string
   default = "googlecompute"


### PR DESCRIPTION
There were errors while trying to create freeBSD 14.2 image by using the older version of the packer (1.6.6). So, install the latest version.

Latest version of the packer requires its plugins to be installed by using 'pg init' command. This is included in this commit as well.

---

Please note that this is a prerequisite commit for the #109.