### PR TITLE
freebsd: Remove version suffix from image names'

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,7 +102,7 @@ task:
   alias: vmbuild-${TASK_NAME}
   matrix:
     - env:
-        TASK_NAME: freebsd-14
+        TASK_NAME: freebsd
         PACKERFILE: packer/freebsd.pkr.hcl
 
     - env:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ pre-commit:
 	packer validate \
 	  -var gcp_project=pg-ci-images-dev \
 	  -var "image_date=$(IMAGE_DATE)" \
-	  -var "image_name=freebsd-14" \
+	  -var "image_name=freebsd" \
 	  packer/freebsd.pkr.hcl
 #	Debian Bullseye
 	packer validate \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ foo_task:
 
 The following images are available:
 
--   FreeBSD images with Postgres are available in the family `pg-ci-freebsd-14`.
+-   FreeBSD images with Postgres are available in the family `pg-ci-freebsd`.
     (If you are looking for images without Postgres, just use FreeBSD's
     [official GCP images](https://cloud.google.com/compute/docs/images#freebsd).)
 

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -7,7 +7,7 @@ locals {
 
   freebsd_gcp_images = [
     {
-      task_name = "freebsd-14"
+      task_name = "freebsd"
       zone = "us-west1-a"
     },
   ]


### PR DESCRIPTION
Previously, all version updated required changes in the Postgres code base. With this change, this won't be necessary anymore.