### PR TITLE
openbsd: Upgrade OpenBSD to 7.7

### DIFF
--- a/packer/openbsd.pkrvars.hcl
+++ b/packer/openbsd.pkrvars.hcl
@@ -2,7 +2,7 @@ name = "openbsd"
 boot_command = [
   "S<enter><wait>",
   "cat <<EOF >>install.conf<enter>",
-  "System hostname = openbsd73<enter>",
+  "System hostname = openbsd77<enter>",
   "Password for root = packer<enter>",
   "Allow root ssh login = yes<enter>",
   "What timezone are you in = Etc/UTC<enter>",
@@ -12,11 +12,11 @@ boot_command = [
   "EOF<enter>",
   "install -af install.conf && reboot<enter>"
 ]
-iso_checksum = "sha256:034435c6e27405d5a7fafb058162943c194eb793dafdc412c08d49bb56b3892a"
+iso_checksum = "sha256:da0106e39463f015524dca806f407c37a9bdd17e6dfffe533b06a2dd2edd8a27"
 iso_urls                = [
-  "install75.iso",
-  "https://cdn.openbsd.org/pub/OpenBSD/7.5/amd64/install75.iso"
+  "install77.iso",
+  "https://cdn.openbsd.org/pub/OpenBSD/7.7/amd64/install77.iso"
 ]
-output_file_name = "output/openbsd7-5.tar.gz"
+output_file_name = "output/openbsd7-7.tar.gz"
 vanilla_name = [ { name = "openbsd-vanilla" } ]
 postgres_name = [ { name = "openbsd-postgres" } ]

--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-PYTHON_VERSION=3.9
-
 pkg_add -I \
     vim--no_x11 git \
     bash \
@@ -23,7 +21,7 @@ pkg_add -I \
     libxslt \
     lz4 \
     openpam \
-    python%${PYTHON_VERSION} \
+    python%3 \
     readline \
     tcl%8.6 \
     zstd \
@@ -31,10 +29,6 @@ pkg_add -I \
     login_krb5 \
     openldap-client--gssapi \
     openldap-server--gssapi
-
-# create a symbolic link to python3, then upgrade pip
-ln -sf /usr/local/bin/python${PYTHON_VERSION} /usr/local/bin/python3
-python3 -m ensurepip --upgrade
 
 #####
 # Add 'noatime' and 'softdep' to the mount points


### PR DESCRIPTION
7.5 version is removed from OpenBSD CDN. Upgrade OpenBSD to the latest version (7.7).

python3 binary is installed as default now, so symbolic link fix is removed.

CI Task: https://cirrus-ci.com/task/6182340436688896