### PR TITLE
windows: Use Windows SDK 10.0.22621.0

### DIFF
--- a/scripts/windows_install_vs_2019.ps1
+++ b/scripts/windows_install_vs_2019.ps1
@@ -14,7 +14,7 @@ Start-Process -Wait `
       '--quiet', '--wait', '--norestart', '--nocache', `
       '--installPath', 'c:\BuildTools', `
       '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', `
-      '--add', 'Microsoft.VisualStudio.Component.Windows10SDK.20348'
+      '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.22621'
 if (!$?) { throw 'cmdfail' }
 
 [Environment]::SetEnvironmentVariable('PATH',  'C:\BuildTools\VC\Auxiliary\Build;' + [Environment]::GetEnvironmentVariable('PATH', 'Machine'), 'Machine')


### PR DESCRIPTION
Windows SDK 10.0.20348.0 was removed from the Visual Studio 2019 installer starting with version 16.11.50. The recommended replacement is 10.0.22621.0, so update to that version.

More information:
https://learn.microsoft.com/en-us/visualstudio/releases/2019/release-notes#16.11.50

Postgres CI run with the new SDK: https://cirrus-ci.com/task/6279273935273984