### PR TITLE
Install docbook-xml on OSes missing it

### DIFF
--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -79,6 +79,7 @@ build {
           p5-IPC-Run \
           \
           curl \
+          docbook-xml \
           liblz4 \
           libbacktrace \
           libxml2 \

--- a/scripts/bsd/netbsd-prep-postgres.sh
+++ b/scripts/bsd/netbsd-prep-postgres.sh
@@ -13,6 +13,7 @@ pkgin -y install \
     meson \
     bison \
     ccache \
+    docbook-xml \
     p5-IPC-Run \
     flex \
     pkgconf \

--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -16,6 +16,7 @@ pkg_add -I \
     \
     p5-IPC-Run \
     \
+    docbook \
     icu4c \
     libxml \
     libxslt \

--- a/scripts/windows_install_mingw64.ps1
+++ b/scripts/windows_install_mingw64.ps1
@@ -19,7 +19,7 @@ msys 'pacman --noconfirm -Scc' ;
 
 echo 'installing packages' ;
 msys 'pacman -S --needed --noconfirm git bison flex make diffutils \
-    ucrt64/mingw-w64-ucrt-x86_64-{ccache,gcc,icu,libbacktrace,libxml2,libxslt,lz4,make,meson,perl,pkg-config,python-pip,zlib}' ;
+    ucrt64/mingw-w64-ucrt-x86_64-{ccache,docbook-xml,gcc,icu,libbacktrace,libxml2,libxslt,lz4,make,meson,perl,pkg-config,python-pip,zlib}' ;
 msys 'pacman -Scc --noconfirm'
 
 # Install perl modules to enable tap tests


### PR DESCRIPTION
The `sgml_sanity_check` (WIP Perl test which checks sanity of *.sgml files) test fails if `docbook-xml` is not present. This commit ensures `docbook-xml` is installed on all the generated images.

Related CI Run: https://cirrus-ci.com/build/6543457239433216