### PR TITLE
mingw: Use UCRT toolchain for mingw-w64

### DIFF
--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -73,8 +73,8 @@ apt-get -y install --no-install-recommends \
   slapd \
   zstd \
   \
-  g++-mingw-w64-x86-64-win32 \
-  gcc-mingw-w64-x86-64-win32 \
+  g++-mingw-w64-ucrt64 \
+  gcc-mingw-w64-ucrt64 \
   libz-mingw-w64-dev \
   mingw-w64-tools
 


### PR DESCRIPTION
Switch CC/CXX to x86_64-w64-mingw32ucrt-* to fix build failure from missing _iswctype_l in mingw-w64 v12 headers.

CI Run that MinGW cross compilation passes: https://cirrus-ci.com/task/5499495296794624