### PR TITLE
Use the latest IPC::Run

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -371,6 +371,14 @@ task:
   name: 'Testing VM Image: ${PREFIX}-${IMAGE_NAME}'
   matrix:
     - env:
+        IMAGE_NAME: bookworm
+        PLATFORM: linux
+
+    - env:
+        IMAGE_NAME: trixie
+        PLATFORM: linux
+
+    - env:
         IMAGE_NAME: netbsd-postgres
         PLATFORM: netbsd
 
@@ -379,7 +387,7 @@ task:
         PLATFORM: openbsd
 
   depends_on:
-    - vmbuild-${PLATFORM}-postgres
+    - vmbuild-${IMAGE_NAME}
 
   compute_engine_instance:
     image_project: $GCP_PROJECT

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -349,6 +349,7 @@ task:
     - uname -a
     - xsltproc --version
     - env
+    - perl -mIPC::Run -e 'print "$IPC::Run::VERSION\n";'
 
 # Disabled linux/arm64, fails currently due to reasons outside of our control
 # task:
@@ -397,6 +398,7 @@ task:
   test_script:
     - uname -a
     - env
+    - perl -mIPC::Run -e 'print "$IPC::Run::VERSION\n";'
 
 
 task:
@@ -415,6 +417,7 @@ task:
     - set
     - where perl
     - perl --version
+    - perl -mIPC::Run -e "print qq{$IPC::Run::VERSION\n};"
     - python --version
     - vcvarsall x64
     - bison --version
@@ -423,5 +426,6 @@ task:
   test_mingw_script:
     - C:\msys64\usr\bin\bash.exe -lc 'where perl'
     - C:\msys64\usr\bin\bash.exe -lc 'perl --version'
+    - C:\msys64\usr\bin\bash.exe -lc 'perl -mIPC::Run -e "print qq{\$IPC::Run::VERSION\\n};"'
     - C:\msys64\usr\bin\bash.exe -lc 'bison --version'
     - C:\msys64\usr\bin\bash.exe -lc 'flex --version'

--- a/docker/linux_debian_ci
+++ b/docker/linux_debian_ci
@@ -4,13 +4,17 @@ FROM debian:${DEBIAN_RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY /scripts/linux_debian_install_deps.sh /scripts/
+COPY /scripts/linux_debian_install_deps.sh /scripts/update_ipc_run.sh /scripts/
 
+# The default port for hkp:// (11371) appears to be blocked somewhere in the
+# Cirrus docker-builder, causing the IPC::Run update to fail. Set
+# MODULE_SIGNATURE_KEYSERVERPORT to 80 to work around it.
 RUN \
   apt-get -y update && \
   apt-get -y upgrade && \
   /scripts/linux_debian_install_deps.sh && \
-  rm /scripts/linux_debian_install_deps.sh && \
+  MODULE_SIGNATURE_KEYSERVERPORT=80 /scripts/update_ipc_run.sh && \
+  rm /scripts/linux_debian_install_deps.sh /scripts/update_ipc_run.sh && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG DATE IMAGE_NAME

--- a/packer/freebsd.pkr.hcl
+++ b/packer/freebsd.pkr.hcl
@@ -76,7 +76,9 @@ build {
           flex \
           gettext \
           \
+          gnupg \
           p5-IPC-Run \
+          p5-Module-Signature \
           \
           curl \
           docbook-xml \
@@ -142,6 +144,10 @@ build {
         echo 'kern.timecounter.smp_tsc_adjust=1' | tee -a /boot/loader.conf
       SCRIPT
     ]
+  }
+
+  provisioner "shell" {
+    script = "scripts/update_ipc_run.sh"
   }
 
   # set IMAGE_IDENTITY to distinguish images on CI runs

--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -199,6 +199,11 @@ build {
 
   provisioner "shell" {
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    script = "scripts/update_ipc_run.sh"
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     inline = [
       <<-SCRIPT
         git clone --single-branch --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git /usr/src/linux

--- a/packer/netbsd_openbsd.pkr.hcl
+++ b/packer/netbsd_openbsd.pkr.hcl
@@ -175,6 +175,10 @@ build {
     only = ["googlecompute.openbsd-postgres"]
   }
 
+  provisioner "shell" {
+    script = "scripts/update_ipc_run.sh"
+  }
+
   # set IMAGE_IDENTITY to distinguish images on CI runs
   provisioner "shell" {
     inline = [

--- a/scripts/bsd/netbsd-prep-postgres.sh
+++ b/scripts/bsd/netbsd-prep-postgres.sh
@@ -14,7 +14,9 @@ pkgin -y install \
     bison \
     ccache \
     docbook-xml \
+    gnupg \
     p5-IPC-Run \
+    p5-Module-Signature \
     flex \
     pkgconf \
     python312 \

--- a/scripts/bsd/openbsd-prep-postgres.sh
+++ b/scripts/bsd/openbsd-prep-postgres.sh
@@ -14,7 +14,9 @@ pkg_add -I \
     ccache \
     gettext-tools \
     \
+    gnupg \
     p5-IPC-Run \
+    p5-Module-Signature \
     \
     docbook \
     icu4c \

--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -43,8 +43,10 @@ apt-get -y install --no-install-recommends \
   gettext \
   python3-pip \
   \
+  gnupg \
   libio-pty-perl \
   libipc-run-perl \
+  libmodule-signature-perl \
   python3-cryptography \
   python3-packaging \
   python3-pytest \

--- a/scripts/update_ipc_run.sh
+++ b/scripts/update_ipc_run.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+set -e
+
+if [ "$(uname)" = "NetBSD" ]
+then
+    # CPAN fails to use the system Perl installation on NetBSD unless the full
+    # directory hierarchy contained in @INC already exists on disk.
+    perl -e 'use File::Path qw(make_path); make_path(@INC);'
+fi
+
+# Upgrade the IPC::Run version to latest, since the version shipped in an OS
+# distribution can lag considerably behind, and tracking down intermittent
+# failures for bugs that have already been fixed is no fun.
+export MODULE_SIGNATURE_KEYSERVER=pgpkeys.eu
+(
+ echo;                            # automate first-time setup
+ echo o conf check_sigs 1;        # check signatures
+ echo o conf init gpg; echo;      # use the default path for gpg
+ echo o conf recommends_policy 0; # don't install "recommended" modules
+ echo notest install IPC::Run;
+) | cpan


### PR DESCRIPTION
As discussed [here](https://www.postgresql.org/message-id/CAOYmi%2BkvZDVLndQ8M2wr5k5wYYVoKF87B3ZOnY37ABQDA0a5GA%40mail.gmail.com).

Local testing has been rough, to say the least -- OpenBSD is the only image I can get working with Packer at the moment -- so I'm hopeful that this tiny draft is enough to either say "yes, good idea" or "no, do it this other way". The second patch in the set is currently untested.