### PR TITLE
Try to update packer image to bookworm

### DIFF
--- a/docker/linux_debian_packer
+++ b/docker/linux_debian_packer
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 RUN \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y update && \


### PR DESCRIPTION
Can't upgrade to trixie, due to the license change having lead to packer being removed from newer versions.  Will need to solve that at some point :(

This currently fails, possibly due to podman changes.