### PR TITLE
Try to update packer image to trixie

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,10 +104,12 @@ task:
     - env:
         TASK_NAME: freebsd
         PACKERFILE: packer/freebsd.pkr.hcl
+        MEMORY: 256Mi
 
     - env:
         PACKERFILE: packer/linux_debian.pkr.hcl
         SCRIPTS: scripts/linux_debian_*
+        MEMORY: 256Mi
 
       matrix:
         - env:
@@ -129,6 +131,8 @@ task:
         PACKERFILE: packer/windows.pkr.hcl
         SCRIPTS: scripts/windows*
         TASK_NAME: windows-ci
+        # 256Mi is not enough after docker image is updated to trixie
+        MEMORY: 512Mi
 
   env:
     IMAGE_NAME: ${PREFIX}-${TASK_NAME}
@@ -138,7 +142,7 @@ task:
   container:
     dockerfile: docker/linux_debian_packer
     cpu: 0.5
-    memory: 256Mi
+    memory: $MEMORY
 
   skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', $SCRIPTS, $PACKERFILE)
   auto_cancellation: false

--- a/docker/linux_debian_packer
+++ b/docker/linux_debian_packer
@@ -1,4 +1,10 @@
-FROM debian:bullseye
+FROM debian:trixie
+# Install Packer 1.9.5, it is the latest version with MPL licence
+# Hardcode the current SHA256 checksum of the Packer binary to ensure we are
+# using the correct version of Packer
+ADD --checksum=sha256:6f8272658a6d606583c2b3deaad272233db6e84a6ee651bf17a0d46d8cea4a9c \
+  https://releases.hashicorp.com/packer/1.9.5/packer_1.9.5_linux_amd64.zip \
+  /tmp/packer.zip
 RUN \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y update && \
@@ -6,9 +12,9 @@ RUN \
   apt-get -y --no-install-recommends install \
     ca-certificates \
     curl \
-    packer \
     podman \
     python3 \
+    unzip \
     qemu-system \
     qemu-utils \
     colorized-logs \
@@ -24,4 +30,10 @@ RUN \
   apt-get install --no-install-recommends -y \
     google-cloud-sdk \
     && \
+  unzip /tmp/packer.zip -d /usr/local/bin/ && \
+  rm /tmp/packer.zip && \
+  chmod +x /usr/local/bin/packer && \
+  # Install required Packer plugins to fix 'Bundled plugins used' warnings
+  packer plugins install github.com/hashicorp/googlecompute && \
+  packer plugins install github.com/hashicorp/qemu && \
   apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There are three changes:

1- Packer's licence is changed from MPL to Business Source License.
Packer 1.9.5 is the latest version with the MPL licence, so install this
version manually.

2- New version of Podman is more strict about using storage overlays and
since we use Podman in the docker container, we can't stack 'overlay'
storage containers. To solve that, we need to use 'vfs' as a storage
driver or we need to install 'fuse-overlayfs' and set it is a
mount_program in the storage.conf. However, there was no default
storage.conf in the docker image and I couldn't find a way to create a
default conf, so this problem is fixed by using '--storage-driver vfs'
option while running the Podman.

3- The container which builds Windows image started to fail due to OOM.
Its memory is increased from 256Mi to 512Mi.

Postgres CI run: https://cirrus-ci.com/build/6391641252036608