### PR TITLE
linux: Partially fix sid build failures

### DIFF
--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -22,19 +22,19 @@ locals {
       task_name = "sid"
       zone = "us-west1-a"
       machine = "t2d-standard-2"
-      source_image_family = "debian-11"
+      source_image_family = "debian-13"
     },
     {
       task_name = "sid-newkernel"
       zone = "us-west1-a"
       machine = "t2d-standard-4"
-      source_image_family = "debian-11"
+      source_image_family = "debian-13"
     },
     {
       task_name = "sid-newkernel-uring"
       zone = "us-west1-a"
       machine = "t2d-standard-4"
-      source_image_family = "debian-11"
+      source_image_family = "debian-13"
     },
   ]
 }
@@ -129,6 +129,7 @@ build {
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     inline = [
       <<-SCRIPT
+        rm -f /etc/apt/sources.list.d/debian.sources
         tee /etc/apt/sources.list <<-EOF
             deb http://deb.debian.org/debian unstable main
             deb-src http://deb.debian.org/debian unstable main

--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -62,7 +62,7 @@ apt-get -y install --no-install-recommends \
   libperl-dev \
   libpython3-dev \
   libreadline-dev \
-  libselinux*-dev \
+  libselinux-dev \
   libssl-dev \
   libsystemd-dev \
   liburing-dev \
@@ -132,7 +132,7 @@ if [ $(dpkg --print-architecture) = "amd64" ] ; then
     libperl-dev:i386 \
     libpython3-dev:i386 \
     libreadline-dev:i386 \
-    libselinux*-dev:i386 \
+    libselinux-dev:i386 \
     libssl-dev:i386 \
     libsystemd-dev:i386 \
     liburing-dev:i386 \


### PR DESCRIPTION
linux: Partially fix sid build failures

This fixes three issues:
- the sid based builds failed because they were based on a
  too old image, leading to upgrading across multiple major versions in one
  step, which is not supported
- the glob to install libselinux matched conflicting packages in sid. But the
  glob isn't needed anymore, now that bullseye isn't built anymore.
- the trixie apt sources were left in place, which lead to some conflicts

This still doesn't succeed in building the image, due to
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1124987
we'll have to wait for that to get fixed.
