### PR TITLE
linux: Mark sid tasks as non-critical

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,10 +116,14 @@ task:
             TASK_NAME: bookworm
         - env:
             TASK_NAME: sid
+          # sid etc aren't critical and break at random times, often transiently
+          allow_failures: true
         - env:
             TASK_NAME: sid-newkernel
+          allow_failures: true
         - env:
             TASK_NAME: sid-newkernel-uring
+          allow_failures: true
 
     - env:
         PACKERFILE: packer/windows.pkr.hcl
@@ -137,7 +141,6 @@ task:
     memory: 256Mi
 
   skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', $SCRIPTS, $PACKERFILE)
-  allow_failures: $CIRRUS_TASK_NAME =~ '.*\[sid\].*'
   auto_cancellation: false
 
   <<: *gcp_auth_unix


### PR DESCRIPTION
The tasks often fail for reasons outside of our control and breakages don't directly affect upstream postgres CI.