### PR TITLE
linux: Install OpenSSL FIPS on Debian Trixie

### DIFF
--- a/packer/linux_debian.pkr.hcl
+++ b/packer/linux_debian.pkr.hcl
@@ -202,6 +202,40 @@ build {
     script = "scripts/update_ipc_run.sh"
   }
 
+  # OpenSSL FIPS will be used only in Debian Trixie for now.
+  provisioner "shell" {
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = [
+      <<-SCRIPT
+        openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module $(find /usr -name fips.so -print -quit)
+        cat > /etc/ssl/openssl-fips.cnf <<-CONF
+          config_diagnostics = 1
+          openssl_conf = openssl_init
+
+          .include /etc/ssl/fipsmodule.cnf
+
+          [openssl_init]
+          providers = provider_sect
+          alg_section = algorithm_sect
+
+          [provider_sect]
+          fips = fips_sect
+          base = base_sect
+
+          [base_sect]
+          activate = 1
+
+          [fips_sect]
+          activate = 1
+
+          [algorithm_sect]
+          default_properties = fips=yes
+        CONF
+      SCRIPT
+    ]
+    only = ["googlecompute.trixie"]
+  }
+
   provisioner "shell" {
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     inline = [

--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -99,6 +99,14 @@ apt-get -y install --no-install-recommends \
   libz-mingw-w64-dev \
   mingw-w64-tools
 
+# openssl-provider-fips is only available on Debian Trixie and sid. This can
+# fail if the new Debian release doesn't have openssl-provider-fips package but
+# failure will notify us so it is okay.
+if [ "$MAJOR_DEBIAN_VERSION" -ge "13" ] ; then
+  apt-get -y install --no-install-recommends \
+    openssl-provider-fips
+fi
+
 # g++-mingw-w64-x86-64-win32 and gcc-mingw-w64-x86-64-win32 packages have
 # missing some functions in the headers starting from trixie, install ucrt64
 # versions on these releases.


### PR DESCRIPTION
OpenSSL FIPS provider isn't tested on the Postgres. OpenSSL FIPS package is available as a openssl-provider-fips package in the Debian Trixie. Install and configure it for testing OpenSSL FIPS provider on the upstream Postgres.

Related CI Run: https://cirrus-ci.com/task/6615163480047616