### PR TITLE
Install readline on mingw

### DIFF
--- a/scripts/windows_install_mingw64.ps1
+++ b/scripts/windows_install_mingw64.ps1
@@ -19,7 +19,7 @@ msys 'pacman --noconfirm -Scc' ;
 
 echo 'installing packages' ;
 msys 'pacman -S --needed --noconfirm git bison flex make diffutils \
-    ucrt64/mingw-w64-ucrt-x86_64-{ccache,docbook-xml,gcc,icu,libbacktrace,libxml2,libxslt,lz4,make,meson,perl,pkg-config,python-cryptography,python-pip,python-pytest,zlib}' ;
+    ucrt64/mingw-w64-ucrt-x86_64-{ccache,docbook-xml,gcc,icu,libbacktrace,libxml2,libxslt,lz4,make,meson,perl,pkg-config,python-cryptography,python-pip,python-pytest,readline,zlib}' ;
 msys 'pacman -Scc --noconfirm'
 
 # Install perl modules to enable tap tests


### PR DESCRIPTION
Recently CFBot has started showing the following errors on MinGW when compiling all patches. Installing the readline package fixed that on my dev branches.

```
[05:40:17.130] Check usable header "Python.h" with dependency python-3.14-embed: YES
[05:40:17.130] Did not find CMake 'cmake'
[05:40:17.130] Found CMake: NO
[05:40:17.130] Run-time dependency readline found: NO (tried pkgconfig and cmake)
[05:40:17.130] Library readline found: NO
[05:40:17.130] Run-time dependency libedit found: NO (tried pkgconfig and cmake)
[05:40:17.130]
[05:40:17.130] meson.build:1480:20: ERROR: C shared or static library 'libedit' not found
[05:40:17.130]
[05:40:17.130] A full log can be found at C:/cirrus/build/meson-logs/meson-log.txt
[05:40:17.258]
[05:40:17.258] c:\cirrus>if 1 NEQ 0 exit /b 1
```
