### PR TITLE
WIP: Pin IPC::Run for other OSes (Debian + BSD)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,11 +104,12 @@ task:
     - env:
         TASK_NAME: freebsd
         PACKERFILE: packer/freebsd.pkr.hcl
+        SCRIPTS: scripts/update_ipc_run.sh
         MEMORY: 256Mi
 
     - env:
         PACKERFILE: packer/linux_debian.pkr.hcl
-        SCRIPTS: scripts/linux_debian_*
+        SCRIPTS: scripts/{update_ipc_run.sh,linux_debian_*}
         MEMORY: 256Mi
 
       matrix:
@@ -218,7 +219,7 @@ task:
     cpu: 2
     memory: 4G
 
-  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', 'files/bsd/*', 'scripts/bsd/*', $PACKERFILE, $PKRVARFILE)
+  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'docker/linux_debian_packer', 'files/bsd/*', 'scripts/update_ipc_run.sh', 'scripts/bsd/*', $PACKERFILE, $PKRVARFILE)
   auto_cancellation: false
 
   <<: *gcp_auth_unix
@@ -297,7 +298,7 @@ task:
         - env:
             DEBIAN_RELEASE: trixie
 
-  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'scripts/linux_debian*', 'docker/linux_debian_ci')
+  skip: $CIRRUS_LAST_GREEN_CHANGE != '' && $CIRRUS_CRON != 'regular-rebuild' && !changesInclude('.cirrus.yml', 'scripts/update_ipc_run.sh', 'scripts/linux_debian*', 'docker/linux_debian_ci')
 
   <<: *gcp_docker_auth_unix
 

--- a/scripts/update_ipc_run.sh
+++ b/scripts/update_ipc_run.sh
@@ -9,14 +9,14 @@ then
     perl -e 'use File::Path qw(make_path); make_path(@INC);'
 fi
 
-# Upgrade the IPC::Run version to latest, since the version shipped in an OS
-# distribution can lag considerably behind, and tracking down intermittent
-# failures for bugs that have already been fixed is no fun.
+# Upgrade the IPC::Run version to latest known-good, since the version shipped
+# in an OS distribution can lag considerably behind, and tracking down
+# intermittent failures for bugs that have already been fixed is no fun.
 export MODULE_SIGNATURE_KEYSERVER=pgpkeys.eu
 (
  echo;                            # automate first-time setup
  echo o conf check_sigs 1;        # check signatures
  echo o conf init gpg; echo;      # use the default path for gpg
  echo o conf recommends_policy 0; # don't install "recommended" modules
- echo notest install IPC::Run;
+ echo notest install NJM/IPC-Run-20250809.0.tar.gz
 ) | cpan


### PR DESCRIPTION
Following the example of ff5238afa.

TODO: the mingw solution checks to make sure IPC::Run isn't already installed, but we can't do that here; do we need to uninstall first? Or strengthen the version checks in .cirrus.yml?