### PR TITLE
linux: Build the 32bit image as a native i386 image

### DIFF
--- a/docker/linux_debian_ci
+++ b/docker/linux_debian_ci
@@ -59,15 +59,50 @@ RUN \
 FROM base AS sanity-check
 
 
-# Image for the linux-meson-32 job
-FROM normal AS linux-meson-32
+# Image for the linux-meson-32 job.
+#
+# This is a native i386 image, rather than an amd64 image cross building with
+# gcc-multilib and a hand maintained list of :i386 -dev packages. The package
+# list is then simply the same one as for the other jobs, and everything that
+# runs during the tests (python/pytest in particular) is 32bit as a matter of
+# course, rather than something we have to arrange for. It also means the job
+# tests a real i386 build, which is what the buildfarm members we care about
+# are doing.
+#
+# The base/normal steps are repeated here rather than shared with the amd64
+# stages above, because a stage's FROM cannot be varied per --target within a
+# single build.
+FROM i386/debian:$DEBIAN_RELEASE AS base-32
+
+LABEL \
+  org.opencontainers.image.source="https://github.com/anarazel/pg-vm-images" \
+  org.opencontainers.image.description="image for running postgres CI"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV IMAGE_NAME=$IMAGE_NAME
+ENV IMAGE_DATE=$DATE
+ENV IMAGE_IDENTITY=$IMAGE_NAME-$DATE
+
+COPY /scripts/linux_debian_install_deps.sh \
+  /scripts/update_ipc_run.sh \
+  /scripts/
+
+FROM base-32 AS linux-meson-32
 
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   \
+  rm -f /etc/apt/apt.conf.d/docker-clean && \
+  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+  \
   /scripts/linux_debian_install_deps.sh \
-    --install-32
+    --install-base && \
+  \
+  MODULE_SIGNATURE_KEYSERVERPORT=80 /scripts/update_ipc_run.sh && \
+  \
+  /scripts/linux_debian_install_deps.sh \
+    --install-normal
 
 
 # Image for the linux-meson-64 job

--- a/scripts/linux_debian_install_deps.sh
+++ b/scripts/linux_debian_install_deps.sh
@@ -14,18 +14,16 @@ Options:
   --install-base    Install minimal-ish build requirements
   --install-normal  Install dependencies for all dependencies and tests
   --install-win     Install windows components
-  --install-32      Install 32bit components
   --install-doc     Install documentation
   -h, --help        Show this help and exit
 EOF
 }
 
-opts=$(getopt -o '' -l help,install-base,install-normal,install-32,install-win,install-doc -- "$@") || exit 1
+opts=$(getopt -o '' -l help,install-base,install-normal,install-win,install-doc -- "$@") || exit 1
 eval set -- "$opts"
 
 install_base=false
 install_normal=false
-install_32=false
 install_win=false
 install_doc=false
 
@@ -33,7 +31,6 @@ while true; do
   case "$1" in
     --install-base)  install_base=true; shift ;;
     --install-normal) install_normal=true; shift ;;
-    --install-32) install_32=true; shift ;;
     --install-win) install_win=true; shift ;;
     --install-doc)   install_doc=true; shift ;;
     --) shift; break ;;
@@ -185,41 +182,6 @@ if "$install_win"; then
             gcc-mingw-w64-ucrt64
         )
     fi
-fi
-
-if "$install_32" && [ $(dpkg --print-architecture) = "amd64" ] ; then
-
-  # Install development packages necessary to target i386 from amd64. Leave
-  # out packages that'd enlarge the image unduly (e.g. llvm-dev).
-  #
-  # Not installing libossp-uuid-dev:i386, systemtap-sdt-dev:i386
-  # they conflict with the amd64 variants
-  dpkg --add-architecture i386
-  apt-get update
-
-  packages+=(
-      gcc-multilib
-
-      libcurl4-openssl-dev:i386
-      libicu-dev:i386
-      libkrb5-*-heimdal:i386
-      libkrb5-dev:i386
-      libldap2-dev:i386
-      liblz4-dev:i386
-      libpam-dev:i386
-      libperl-dev:i386
-      libpython3-dev:i386
-      libreadline-dev:i386
-      libselinux-dev:i386
-      libssl-dev:i386
-      libsystemd-dev:i386
-      liburing-dev:i386
-      libxml2-dev:i386
-      libxslt1-dev:i386
-      libzstd-dev:i386
-      tcl-dev:i386
-      uuid-dev:i386
-  )
 fi
 
 if "$install_doc"; then


### PR DESCRIPTION
The `linux-meson-32` image was an amd64 image that cross built for i386 with `gcc-multilib` and a hand maintained list of `:i386` -dev packages. That already caused problems because `libossp-uuid-dev:i386` and `systemtap-sdt-dev:i386` conflict with their amd64 counterparts and had to be left out. For the effort to introduce pytest support in our test suite the same thing holds true, a 32bit and 64bit python executable cannot be installed together.

To solve that problem this starts basing the image on `i386/debian` instead. That way we actually get a whole 32bit OS instead of one that's half 32bit.

Related to #143
